### PR TITLE
Fix for laravel 5.8

### DIFF
--- a/src/Krucas/Settings/Settings.php
+++ b/src/Krucas/Settings/Settings.php
@@ -431,7 +431,7 @@ class Settings implements Repository
         $payload[] = $this->context;
 
         if ($this->isEventsEnabled()) {
-            $this->dispatcher->fire("settings.{$event}: {$key}", $payload);
+            $this->dispatcher->dispatch("settings.{$event}: {$key}", $payload);
         }
     }
 }


### PR DESCRIPTION
Since the fire method has been removed we need to replace it with the dispatch method.