### PR TITLE
Support for Laravel 6. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.0
+  - 7.2
   - hhvm
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 7.2
 
+
+
 before_script:
   - curl -s http://getcomposer.org/installer | php
   - php composer.phar install --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 php:
   - 7.2
-  - hhvm
 
 before_script:
   - curl -s http://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php" : "^5.5|^7.2",
+    "php" : "^7.2",
     "illuminate/support": "^6.0",
     "illuminate/console": "^6.0",
     "illuminate/database": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php" : "^5.5|^7.0",
+    "php" : "^5.5|^7.2",
     "illuminate/support": "^6.0",
     "illuminate/console": "^6.0",
     "illuminate/database": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,14 @@
   "license": "MIT",
   "require": {
     "php" : "^5.5|^7.0",
-    "illuminate/support": "^5.2",
-    "illuminate/console": "^5.2",
-    "illuminate/database": "^5.2",
-    "illuminate/filesystem": "^5.2"
+    "illuminate/support": "^6.0",
+    "illuminate/console": "^6.0",
+    "illuminate/database": "^6.0",
+    "illuminate/filesystem": "^6.0"
   },
   "require-dev": {
-    "mockery/mockery": "0.9.*"
+    "mockery/mockery": "^1.0",
+    "phpunit/phpunit": "8"
   },
   "autoload": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,18 @@
       "email": "edv.krucas@gmail.com"
     }
   ],
+
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Krucas\\Settings\\Providers\\SettingsServiceProvider"
+      ],
+      "aliases": {
+        "Settings": "Krucas\\Settings\\Facades\\Settings"
+      }
+    }
+  },
+
   "license": "MIT",
   "require": {
     "php" : "^7.2",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
         >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/src/Krucas/Settings/Console/SettingsTableCommand.php
+++ b/src/Krucas/Settings/Console/SettingsTableCommand.php
@@ -51,7 +51,7 @@ class SettingsTableCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $fullPath = $this->createBaseMigration();
 

--- a/src/Krucas/Settings/Settings.php
+++ b/src/Krucas/Settings/Settings.php
@@ -249,7 +249,7 @@ class Settings implements Repository
     /**
      * Return event dispatcher instance.
      *
-     * @return \\Illuminate\Contracts\Events\Dispatcher|null
+     * @return \Illuminate\Contracts\Events\Dispatcher|null
      */
     public function getDispatcher()
     {
@@ -290,7 +290,6 @@ class Settings implements Repository
         $this->fire('checking', $key, [$key]);
 
         $status = $this->repository->has($this->getKey($key));
-
         $this->fire('has', $key, [$key, $status]);
 
         $this->context(null);
@@ -431,7 +430,7 @@ class Settings implements Repository
         $payload[] = $this->context;
 
         if ($this->isEventsEnabled()) {
-            $this->dispatcher->fire("settings.{$event}: {$key}", $payload);
+            $this->dispatcher->dispatch("settings.{$event}: {$key}", $payload);
         }
     }
 }

--- a/tests/ContextSerializerTest.php
+++ b/tests/ContextSerializerTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class ContextSerializerTest extends PHPUnit_Framework_TestCase
+class ContextSerializerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown():void
     {
         m::close();
     }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class ContextTest extends PHPUnit_Framework_TestCase
+class ContextTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown():void
     {
         m::close();
     }
@@ -37,11 +38,10 @@ class ContextTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($context->has('test'));
     }
 
-    /**
-     * @expectedException \OutOfBoundsException
-     */
+
     public function testGetUndefinedContextArgument()
     {
+        $this->expectException(\OutOfBoundsException::class);
         $context = new \Krucas\Settings\Context();
         $context->get('test');
     }

--- a/tests/KeyGeneratorTest.php
+++ b/tests/KeyGeneratorTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use Mockery as m;
-
-class KeyGeneratorTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+class KeyGeneratorTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown():void
     {
         m::close();
     }

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use Mockery as m;
-
-class SettingsTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+class SettingsTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown():void
     {
         m::close();
     }
@@ -36,14 +36,15 @@ class SettingsTest extends PHPUnit_Framework_TestCase
         $mock->shouldReceive('has')->with('key_g')->andReturn(true);
 
         $dispatcher = $this->getDispatcherMock();
-        $dispatcher->shouldReceive('fire')->once()->with('settings.checking: key', ['key', $context]);
-        $dispatcher->shouldReceive('fire')->once()->with('settings.has: key', ['key', true, $context]);
+        $dispatcher->shouldReceive('dispatch')->once()->with('settings.checking: key', ['key', $context]);
+        $dispatcher->shouldReceive('dispatch')->once()->with('settings.has: key', ['key', true, $context]);
 
         $valueSerializer = $this->getValueSerializerMock();
 
         $settings = new \Krucas\Settings\Settings($mock, $g, $valueSerializer);
         $settings->enableEvents();
         $settings->setDispatcher($dispatcher);
+
 
         $this->assertTrue($settings->context($context)->has('key'));
     }
@@ -57,7 +58,7 @@ class SettingsTest extends PHPUnit_Framework_TestCase
         $mock->shouldReceive('has')->with('key_g')->andReturn(true);
 
         $dispatcher = $this->getDispatcherMock();
-        $dispatcher->shouldReceive('fire')->never();
+        $dispatcher->shouldReceive('dispatch')->never();
 
         $valueSerializer = $this->getValueSerializerMock();
 
@@ -194,8 +195,8 @@ class SettingsTest extends PHPUnit_Framework_TestCase
         $mock->shouldReceive('get')->once()->with('key_g', 'default')->andReturn('serialized');
 
         $dispatcher = $this->getDispatcherMock();
-        $dispatcher->shouldReceive('fire')->once()->with('settings.getting: key', ['key', 'default', $context]);
-        $dispatcher->shouldReceive('fire')->once()->with('settings.get: key', ['key', 'value', 'default', $context]);
+        $dispatcher->shouldReceive('dispatch')->once()->with('settings.getting: key', ['key', 'default', $context]);
+        $dispatcher->shouldReceive('dispatch')->once()->with('settings.get: key', ['key', 'value', 'default', $context]);
 
         $valueSerializer = $this->getValueSerializerMock();
         $valueSerializer->shouldReceive('unserialize')->with('serialized')->andReturn('value');
@@ -216,7 +217,7 @@ class SettingsTest extends PHPUnit_Framework_TestCase
         $mock->shouldReceive('get')->once()->with('key_g', 'default')->andReturn('serialized');
 
         $dispatcher = $this->getDispatcherMock();
-        $dispatcher->shouldReceive('fire')->never();
+        $dispatcher->shouldReceive('dispatch')->never();
 
         $valueSerializer = $this->getValueSerializerMock();
         $valueSerializer->shouldReceive('unserialize')->with('serialized')->andReturn('value');
@@ -339,8 +340,8 @@ class SettingsTest extends PHPUnit_Framework_TestCase
         $mock->shouldReceive('set')->once()->with('key_g', 'serialized');
 
         $dispatcher = $this->getDispatcherMock();
-        $dispatcher->shouldReceive('fire')->once()->with('settings.setting: key', ['key', 'value', $context]);
-        $dispatcher->shouldReceive('fire')->once()->with('settings.set: key', ['key', 'value', $context]);
+        $dispatcher->shouldReceive('dispatch')->once()->with('settings.setting: key', ['key', 'value', $context]);
+        $dispatcher->shouldReceive('dispatch')->once()->with('settings.set: key', ['key', 'value', $context]);
 
         $valueSerializer = $this->getValueSerializerMock();
         $valueSerializer->shouldReceive('serialize')->with('value')->andReturn('serialized');
@@ -361,7 +362,7 @@ class SettingsTest extends PHPUnit_Framework_TestCase
         $mock->shouldReceive('set')->once()->with('key_g', 'serialized');
 
         $dispatcher = $this->getDispatcherMock();
-        $dispatcher->shouldReceive('fire')->never();
+        $dispatcher->shouldReceive('dispatch')->never();
 
         $valueSerializer = $this->getValueSerializerMock();
         $valueSerializer->shouldReceive('serialize')->with('value')->andReturn('serialized');
@@ -439,8 +440,8 @@ class SettingsTest extends PHPUnit_Framework_TestCase
         $mock->shouldReceive('forget')->once()->with('key_g');
 
         $dispatcher = $this->getDispatcherMock();
-        $dispatcher->shouldReceive('fire')->once()->with('settings.forgetting: key', ['key', $context]);
-        $dispatcher->shouldReceive('fire')->once()->with('settings.forget: key', ['key', $context]);
+        $dispatcher->shouldReceive('dispatch')->once()->with('settings.forgetting: key', ['key', $context]);
+        $dispatcher->shouldReceive('dispatch')->once()->with('settings.forget: key', ['key', $context]);
 
         $valueSerializer = $this->getValueSerializerMock();
 
@@ -460,7 +461,7 @@ class SettingsTest extends PHPUnit_Framework_TestCase
         $mock->shouldReceive('forget')->once()->with('key_g');
 
         $dispatcher = $this->getDispatcherMock();
-        $dispatcher->shouldReceive('fire')->never();
+        $dispatcher->shouldReceive('dispatch')->never();
 
         $valueSerializer = $this->getValueSerializerMock();
 

--- a/tests/ValueSerializerTest.php
+++ b/tests/ValueSerializerTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use Mockery as m;
-
-class ValueSerializerTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+class ValueSerializerTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown():void
     {
         m::close();
     }


### PR DESCRIPTION
I made the package working for Laravel 6.X. Minimum PHP required is same as Laravel, 7.2

Also all tests were upgraded to work with newest PHPUnit.

All tests are passing

Please review and potentially approve into new version - 3.x?

